### PR TITLE
Add const ZERO for use in statics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ pub trait Monotonic {
     /// extending a 16 bit timer to 32/64 bits, even if there are no scheduled tasks.
     const DISABLE_INTERRUPT_ON_EMPTY_QUEUE: bool = true;
 
+    /// The time at time zero. Can be used in statics, unlike the [zero()](crate::Monotonic::zero) function.
+    const ZERO: Self::Instant;
+
     /// The type for instant, defining an instant in time.
     ///
     /// **Note:** In all APIs in RTIC that use instants from this monotonic, this type will be used.


### PR DESCRIPTION
Wanted to initialise an Instant in a static, but I couldn't because zero() is a (non-const) fn. AFAIK you can't have const fns in traits, so no constifying zero() - this is the next best thing, I think.
Since [from_ticks()](https://docs.rs/fugit/latest/fugit/struct.Instant.html#method.from_ticks) in fugit is const, implementing this is the same as zero() -
```rust
const ZERO: Self::Instant = Self::Instant::from_ticks(0);
````