### PR TITLE
docs: Emphasize rtic-monotonic is for RTIC v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 [![crates.io](https://img.shields.io/crates/v/rtic-monotonic.svg)](https://crates.io/crates/rtic-monotonic)
 [![crates.io](https://img.shields.io/crates/d/rtic-monotonic.svg)](https://crates.io/crates/rtic-monotonic)
 
-# `rtic-monotonic`
+# `rtic-monotonic` for RTIC v1
 
 > Core abstractions of the Real-Time Interrupt-driven Concurrency (RTIC) Monotonic timers
 
 # [Documentation](https://docs.rs/rtic-monotonic)
+
+This crate contains the trait and will need an actual implementation to be useful.
+
+## For RTIC v2 see [rtic-time](https://github.com/rtic-rs/rtic/tree/master/rtic-time) instead
 
 # License
 


### PR DESCRIPTION
Provide a link for RTIC v2 rtic-time successor
